### PR TITLE
fix: disabled trade button

### DIFF
--- a/src/components/trade/TradeInterface.tsx
+++ b/src/components/trade/TradeInterface.tsx
@@ -276,6 +276,14 @@ export default function TradeInterface({
     onTradeSuccessful()
   }
 
+  const isTradeButtonDisabled =
+    txManager.isPending ||
+    !isValid ||
+    exceedsBalance ||
+    isMissingAllowance ||
+    !parseFloat(ideaTokenAmount) ||
+    parseFloat(ideaTokenAmount) <= 0.0
+
   return (
     <>
       {showTypeSelection && (
@@ -530,21 +538,11 @@ export default function TradeInterface({
                 <button
                   className={classNames(
                     'ml-6 w-28 md:w-40 h-12 text-base border-2 rounded-lg tracking-tightest-2 ',
-                    txManager.isPending ||
-                      !isValid ||
-                      exceedsBalance ||
-                      isMissingAllowance ||
-                      !parseFloat(ideaTokenAmount) ||
-                      parseFloat(ideaTokenAmount) <= 0.0
+                    isTradeButtonDisabled
                       ? 'text-brand-gray-2 bg-brand-gray cursor-default border-brand-gray'
                       : 'border-brand-blue text-white bg-brand-blue font-medium'
                   )}
-                  disabled={
-                    txManager.isPending ||
-                    exceedsBalance ||
-                    !parseFloat(ideaTokenAmount) ||
-                    parseFloat(ideaTokenAmount) <= 0.0
-                  }
+                  disabled={isTradeButtonDisabled}
                   onClick={onTradeClicked}
                 >
                   {tradeType === 'buy' ? 'Buy' : 'Sell'}


### PR DESCRIPTION
## Bug:
The user is able to sell without unlocking first, despite the sell/buy is visually disabled.

The condition was correct for the classname, but not for the disabled prop on the trade/sell button as discussed over here (https://github.com/Ideamarket/ideamarket-frontend/pull/69#issuecomment-850973513)


## Video
https://www.loom.com/share/5abc12c22ed944d9b4f20bbaa879a3d2

## Env
https://dev.ideamarket.io/
