### PR TITLE
feature: added image component from nextjs

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,13 @@ module.exports = withPWA({
     dest: 'public',
     disable: process.env.NODE_ENV === 'development',
   },
+  images: {
+    domains: [
+      'd3hjr60szea5ud.cloudfront.net',
+      'app.ideamarket.io',
+      'raw.githubusercontent.com',
+    ],
+  },
   async redirects() {
     return [
       {

--- a/public/gray.svg
+++ b/public/gray.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+<path d="M0,0h1v1H0" fill="#cbd5e0"/>
+</svg>

--- a/src/components/ListTokenModal.tsx
+++ b/src/components/ListTokenModal.tsx
@@ -266,6 +266,7 @@ export default function ListTokenModal({ close }: { close: () => void }) {
                     )
               }
             >
+              {/* TODO: replace <img/> with <Image /> OnLoadingComlete when Next v11.0.2 will be released */}
               <img
                 className={classNames(
                   'rounded-full max-w-12 max-h-12 ml-3 inline-block',

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 import { Router, useRouter } from 'next/dist/client/router'
+import Image from 'next/image'
 import { useState, useEffect } from 'react'
 import { WalletStatus } from 'components'
 import Close from '../assets/close.svg'
@@ -66,15 +67,17 @@ export default function Nav() {
         <div className="px-2 mx-auto transform max-w-88 md:max-w-304">
           <div className="relative flex items-center justify-between h-16">
             <div
-              className="z-20 flex items-center flex-shrink-0 cursor-pointer"
+              className="z-20 flex items-center flex-shrink-0 cursor-pointer "
               onClick={() => router.push('/')}
             >
-              <img
-                className="block w-auto h-8"
-                src="/logo.png"
-                alt="Workflow logo"
-              />
-
+              <div className="relative w-10 h-8">
+                <Image
+                  src="/logo.png"
+                  alt="Workflow logo"
+                  layout="fill"
+                  objectFit="contain"
+                />
+              </div>
               <span className="w-auto h-full text-2xl leading-none text-white md:text-3xl font-gilroy-bold">
                 Ideamarket
               </span>

--- a/src/components/listing-page/ListingOverview.tsx
+++ b/src/components/listing-page/ListingOverview.tsx
@@ -13,6 +13,7 @@ import {
 import A from 'components/A'
 import { useTokenIconURL } from 'actions'
 import { BadgeCheckIcon } from '@heroicons/react/solid'
+import Image from 'next/image'
 
 const tenPow18 = new BigNumber('10').pow(new BigNumber('18'))
 
@@ -79,11 +80,17 @@ export default function TokenCard({
   return (
     <>
       <div className="flex flex-none mt-7">
-        <div className="w-20 h-20 mr-5">
+        <div className="w-20 h-20 mr-5 relative">
           {loading || isTokenIconLoading ? (
             <div className="bg-gray-400 rounded-full w-18 h-18 animate animate-pulse"></div>
           ) : (
-            <img className="rounded-full" src={tokenIconURL} alt="" />
+            <Image
+              className="rounded-full"
+              src={tokenIconURL || '/gray.svg'}
+              alt=""
+              layout="fill"
+              objectFit="contain"
+            />
           )}
         </div>
         <div className="mt-1 text-2xl font-semibold text-brand-alto">

--- a/src/components/listing-page/ListingStats.tsx
+++ b/src/components/listing-page/ListingStats.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import array from 'lodash/array'
 import { ListingOverview, TimeXFloatYChartInLine } from 'components'
 import A from 'components/A'
+import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { useQuery } from 'react-query'
@@ -118,12 +119,8 @@ export default function ListingStats({ isLoading, market, token }) {
           >
             Listings
           </span>
-          <span>
-            <img
-              className="inline-block w-2 ml-2 mr-2"
-              src="/arrow@3x.png"
-              alt=""
-            />
+          <span className="inline-block w-2 ml-2 mr-2">
+            <Image src="/arrow@3x.png" height={12} width={8} alt="" />
           </span>
           <span className="text-base font-medium text-brand-gray text-opacity-60">
             {market?.name || '..'}

--- a/src/components/mutual-tokens/MutualToken.tsx
+++ b/src/components/mutual-tokens/MutualToken.tsx
@@ -8,6 +8,7 @@ import {
 import { MutualTokensListSortBy, A } from 'components'
 import { useTokenIconURL } from 'actions'
 import useThemeMode from 'components/useThemeMode'
+import Image from 'next/image'
 
 export default function MutualToken({
   stats,
@@ -37,11 +38,15 @@ export default function MutualToken({
                 {isTokenIconLoading ? (
                   <div className="w-20 h-20 mx-auto bg-gray-400 rounded-full animate-pulse"></div>
                 ) : (
-                  <img
-                    className="w-20 h-20 mx-auto rounded-full"
-                    src={tokenIconURL}
-                    alt={token.name}
-                  />
+                  <div className="relative w-20 h-20 mx-auto">
+                    <Image
+                      src={tokenIconURL || '/gray.svg'}
+                      alt={token.name}
+                      layout="fill"
+                      objectFit="contain"
+                      className="rounded-full"
+                    />
+                  </div>
                 )}
               </div>
               <div className="mt-4 text-center lg:mt-0 lg:pt-1 lg:text-left">

--- a/src/components/tokens/LockedTokenRow.tsx
+++ b/src/components/tokens/LockedTokenRow.tsx
@@ -17,6 +17,7 @@ import { A, AddToMetamaskButton } from 'components'
 import { useTokenIconURL } from 'actions'
 import { BadgeCheckIcon } from '@heroicons/react/solid'
 import useThemeMode from 'components/useThemeMode'
+import Image from 'next/image'
 
 const tenPow18 = new BigNumber('10').pow(new BigNumber('18'))
 
@@ -87,11 +88,15 @@ export default function LockedTokenRow({
               {isTokenIconLoading ? (
                 <div className="w-full h-full bg-gray-400 rounded-full animate-pulse"></div>
               ) : (
-                <img
-                  className="w-full h-full rounded-full"
-                  src={tokenIconURL}
-                  alt=""
-                />
+                <div className="w-full h-full relative">
+                  <Image
+                    src={tokenIconURL || '/gray.svg'}
+                    alt="token"
+                    layout="fill"
+                    objectFit="contain"
+                    className="rounded-full"
+                  />
+                </div>
               )}
             </div>
             <div className="ml-4 text-base font-semibold leading-5">

--- a/src/components/tokens/MyTokenRow.tsx
+++ b/src/components/tokens/MyTokenRow.tsx
@@ -13,6 +13,7 @@ import A from 'components/A'
 import { useTokenIconURL } from 'actions'
 import { BadgeCheckIcon } from '@heroicons/react/solid'
 import useThemeMode from 'components/useThemeMode'
+import Image from 'next/image'
 
 const tenPow18 = new BigNumber('10').pow(new BigNumber('18'))
 
@@ -59,11 +60,15 @@ export default function MyTokenRow({
               {isTokenIconLoading ? (
                 <div className="w-full h-full bg-gray-400 dark:bg-gray-600 rounded-full animate-pulse"></div>
               ) : (
-                <img
-                  className="w-full h-full rounded-full"
-                  src={tokenIconURL}
-                  alt=""
-                />
+                <div className="w-full h-full relative">
+                  <Image
+                    src={tokenIconURL || '/gray.svg'}
+                    alt="token"
+                    layout="fill"
+                    objectFit="contain"
+                    className="rounded-full"
+                  />
+                </div>
               )}
             </div>
             <div className="ml-4 text-base font-semibold leading-5">

--- a/src/components/tokens/OverviewTokenRow.tsx
+++ b/src/components/tokens/OverviewTokenRow.tsx
@@ -20,6 +20,7 @@ import {
 import { useQuery } from 'react-query'
 import { BadgeCheckIcon, ArrowSmUpIcon } from '@heroicons/react/solid'
 import useThemeMode from 'components/useThemeMode'
+import Image from 'next/image'
 
 const tenPow18 = new BigNumber('10').pow(new BigNumber('18'))
 
@@ -113,11 +114,15 @@ export default function TokenRow({
               {isTokenIconLoading ? (
                 <div className="w-full h-full bg-gray-400 rounded-full animate-pulse"></div>
               ) : (
-                <img
-                  className="w-full h-full rounded-full"
-                  src={tokenIconURL}
-                  alt=""
-                />
+                <div className="w-full h-full rounded-full relative">
+                  <Image
+                    src={tokenIconURL || '/gray.svg'}
+                    alt="token"
+                    layout="fill"
+                    objectFit="contain"
+                    className="rounded-full"
+                  />
+                </div>
               )}
             </div>
             <div className="ml-4 text-base font-medium leading-5 truncate hover:underline">

--- a/src/components/tokens/OverviewTokenTable.tsx
+++ b/src/components/tokens/OverviewTokenTable.tsx
@@ -212,7 +212,7 @@ export default function Table({
             <div className="border-b border-gray-200 dark:border-gray-500 sm:rounded-t-lg overflow-x-scroll lg:overflow-x-visible">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-500">
                 <thead className="hidden md:table-header-group">
-                  <tr className="lg:sticky md:top-44 sticky-safari">
+                  <tr className="lg:sticky md:top-44 sticky-safari z-10">
                     <OverviewColumns
                       currentColumn={currentColumn}
                       orderDirection={orderDirection}

--- a/src/components/tokens/OwnedTokenRow.tsx
+++ b/src/components/tokens/OwnedTokenRow.tsx
@@ -19,6 +19,7 @@ import { BadgeCheckIcon } from '@heroicons/react/solid'
 import ModalService from 'components/modals/ModalService'
 import LockModal from 'components/trade/LockModal'
 import useThemeMode from 'components/useThemeMode'
+import Image from 'next/image'
 
 const tenPow18 = new BigNumber('10').pow(new BigNumber('18'))
 
@@ -88,11 +89,15 @@ export default function TokenRow({
               {isTokenIconLoading ? (
                 <div className="w-full h-full bg-gray-400 dark:bg-gray-600 rounded-full animate-pulse"></div>
               ) : (
-                <img
-                  className="w-full h-full rounded-full"
-                  src={tokenIconURL}
-                  alt=""
-                />
+                <div className="w-full h-full rounded-full relative">
+                  <Image
+                    src={tokenIconURL || '/gray.svg'}
+                    alt="token"
+                    layout="fill"
+                    objectFit="contain"
+                    className="rounded-full"
+                  />
+                </div>
               )}
             </div>
             <div className="ml-4 text-base font-semibold leading-5">

--- a/src/components/tokens/TokenCard.tsx
+++ b/src/components/tokens/TokenCard.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils'
 import { useTokenIconURL } from 'actions'
 import useThemeMode from 'components/useThemeMode'
+import Image from 'next/image'
 
 const tenPow18 = new BigNumber('10').pow(new BigNumber('18'))
 
@@ -59,11 +60,15 @@ export default function TokenCard({
         {loading || isTokenIconLoading ? (
           <div className="bg-gray-400 rounded-full w-18 h-18 animate animate-pulse"></div>
         ) : (
-          <img
-            className="rounded-full max-w-18 max-h-18"
-            src={tokenIconURL}
-            alt=""
-          />
+          <div className="w-full h-full rounded-full relative max-w-18 max-h-18">
+            <Image
+              src={tokenIconURL || '/gray.svg'}
+              alt="token"
+              layout="fill"
+              objectFit="contain"
+              className="rounded-full"
+            />
+          </div>
         )}
       </div>
       <div className="mt-1 text-4xl font-semibold text-center">

--- a/src/components/trade/components/SelectTokenFormat.tsx
+++ b/src/components/trade/components/SelectTokenFormat.tsx
@@ -1,12 +1,17 @@
+import Image from 'next/image'
+
 const SelectTokensFormat = ({ token }) => (
   <div className="flex flex-row items-center w-full">
     <div className="flex items-center">
-      <img
-        className="w-7.5"
-        style={{ minWidth: 24, minHeight: 24 }}
-        src={token.logoURL}
-        alt="logo"
-      />
+      <div className="w-7 h-7 relative">
+        <Image
+          src={token?.logoURL || '/gray.svg'}
+          alt="token"
+          layout="fill"
+          objectFit="contain"
+          className="rounded-full"
+        />
+      </div>
     </div>
     <div className="ml-2.5 dark:text-gray-300">
       <div>{token.symbol}</div>

--- a/src/components/trade/components/TradeInterfaceBox.tsx
+++ b/src/components/trade/components/TradeInterfaceBox.tsx
@@ -2,6 +2,7 @@ import { TransactionManager } from 'utils'
 import { TokenListEntry } from '../../../store/tokenListStore'
 import { useEffect, useState } from 'react'
 import TokenSelect from './TokenSelect'
+import Image from 'next/image'
 
 type TradeInterfaceBoxProps = {
   label: string
@@ -143,12 +144,15 @@ const TradeInterfaceBox: React.FC<TradeInterfaceBoxProps> = ({
             <div className="flex items-center px-2 py-1 bg-white dark:bg-gray-700 shadow-md rounded-2xl">
               <div className="flex items-center">
                 {selectedIdeaToken?.logoURL ? (
-                  <img
-                    className="w-7.5 rounded-full"
-                    style={{ minWidth: 24, minHeight: 24 }}
-                    src={selectedIdeaToken?.logoURL}
-                    alt="token"
-                  />
+                  <div className="w-7 h-7 relative">
+                    <Image
+                      src={selectedIdeaToken?.logoURL || '/gray.svg'}
+                      alt="token"
+                      layout="fill"
+                      objectFit="contain"
+                      className="rounded-full"
+                    />
+                  </div>
                 ) : (
                   <div className="w-7.5 h-7.5 rounded-full bg-gray-400 animate animate-pulse" />
                 )}

--- a/src/components/wallet/WrongNetworkOverlay.tsx
+++ b/src/components/wallet/WrongNetworkOverlay.tsx
@@ -3,6 +3,7 @@ import { useWalletStore } from 'store/walletStore'
 import { NETWORK } from 'store/networks'
 
 import dynamic from 'next/dynamic'
+import Image from 'next/image'
 
 const NoSSRWalletInterface = dynamic(() => import('./WalletInterface'), {
   ssr: false,
@@ -33,11 +34,15 @@ export default function WrongNetworkOverlay() {
     <div className="absolute top-0 left-0 z-50 w-screen h-screen bg-gray-200 dark:bg-gray-800">
       <div className="flex items-center justify-center w-full h-full overflow-auto">
         <div className="flex flex-col items-center">
-          <img
-            className="block w-auto h-32 md:h-64"
-            src="/logo.png"
-            alt="Workflow logo"
-          />
+          <div className="relative w-full h-32 md:h-64">
+            <Image
+              src="/logo.png"
+              alt="Workflow logo"
+              layout="fill"
+              objectFit="contain"
+            />
+          </div>
+
           <h1 className="mt-5 text-2xl md:text-3xl">
             Change network selection
           </h1>

--- a/src/pages/iframe/[marketName]/[tokenName].tsx
+++ b/src/pages/iframe/[marketName]/[tokenName].tsx
@@ -1,6 +1,7 @@
 import { ArrowCircleUpIcon } from '@heroicons/react/solid'
 import { useTokenIconURL } from 'actions'
 import { A } from 'components'
+import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useQuery } from 'react-query'
 import { querySingleToken } from 'store/ideaMarketsStore'
@@ -65,11 +66,12 @@ export default function IframeEmbed() {
   return (
     <div className="w-full h-full p-2">
       <div className="flex items-center w-full h-full p-2 shadow-embed rounded-2xl">
-        <div className="flex-grow-0">
-          <img
-            className="block w-8 h-auto"
+        <div className="flex-grow-0 w-8 h-8 relative">
+          <Image
             src="/logo-32x32.png"
             alt="Ideamarket Logo"
+            layout="fill"
+            objectFit="contain"
           />
         </div>
 
@@ -77,11 +79,15 @@ export default function IframeEmbed() {
           {isLoading ? (
             <div className="w-8 h-8 bg-gray-400 animate-pulse" />
           ) : (
-            <img
-              src={tokenIconURL}
-              alt={rawTokenName}
-              className="w-8 h-auto rounded-full"
-            />
+            <div className="w-8 h-8 relative">
+              <Image
+                src={tokenIconURL || '/gray.svg'}
+                alt={rawTokenName}
+                className="rounded-full"
+                layout="fill"
+                objectFit="contain"
+              />
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Jira ticket
[https://ideamarketio.atlassian.net/browse/IDEAMARKET-95](https://ideamarketio.atlassian.net/browse/IDEAMARKET-95)

## Summary
- Replaced all img into nextjs <Image /> component (besides the img for facebook pixel in `_docucent.tsx`)
- for the external images I needed to add the fallback ('gray.svg'), I guess the better way would be to pass in the loading animation, but the component seems to expect a static image. Maybe loading images on SSR would fix this?
- for images without sizes to fill the container we need the wrapper (as on the example from nextJS - [https://github.com/vercel/next.js/blob/canary/examples/image-component/pages/layout-fill.js](https://github.com/vercel/next.js/blob/canary/examples/image-component/pages/layout-fill.js) )