### PR TITLE
feature: added template for PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## Jira ticket
+[https://ideamarketio.atlassian.net/browse/IDEAMARKET-XX](https://ideamarketio.atlassian.net/browse/IDEAMARKET-XX)
+
+## Summary


### PR DESCRIPTION
## Jira ticket
[https://ideamarketio.atlassian.net/browse/IDEAMARKET-XX](https://ideamarketio.atlassian.net/browse/IDEAMARKET-XX)

## Summary
What do you guys think about adding a simple template for the PRs. I think it could come in handy to include the Jira ticked to the PR (if there is one) and a quick summary of the changes in the PR.

docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository