### PR TITLE
fix: fixed graph bug by only allowing one chart at a time with one ref

### DIFF
--- a/src/components/charts/TimeXFloatYChartInLine.tsx
+++ b/src/components/charts/TimeXFloatYChartInLine.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Chart from 'chart.js'
 import { getAxes, getMinMax, getTimePeriod } from './utils'
 
@@ -8,76 +8,84 @@ export default function TimeXFloatYChartInLine({
   chartDurationSeconds,
 }) {
   const ref = useRef(null)
+  const [chart, setChart] = useState(null)
 
   useEffect(() => {
+    if (chart) {
+      chart.destroy()
+    }
+
     const timePeriodArray = getTimePeriod(chartFromTs, chartDurationSeconds)
 
     const { xAxe, yAxe } = getAxes(chartData, timePeriodArray, chartFromTs)
 
     const { min, max } = getMinMax(yAxe)
 
-    new Chart(ref.current.getContext('2d'), {
-      type: 'line',
-      data: {
-        labels: xAxe,
-        datasets: [
-          {
-            data: yAxe,
-            pointRadius: 0,
-            fill: false,
-            borderColor: '#08a2dd',
-            borderWidth: 3,
-            lineTension: 0.25,
+    setChart(
+      new Chart(ref.current.getContext('2d'), {
+        type: 'line',
+        data: {
+          labels: xAxe,
+          datasets: [
+            {
+              data: yAxe,
+              pointRadius: 0,
+              fill: false,
+              borderColor: '#08a2dd',
+              borderWidth: 3,
+              lineTension: 0.25,
+            },
+          ],
+        },
+        options: {
+          animation: {
+            duration: 0,
           },
-        ],
-      },
-      options: {
-        animation: {
-          duration: 0,
-        },
-        responsive: true,
-        maintainAspectRatio: false,
-        legend: {
-          display: false,
-        },
-        scales: {
-          xAxes: [
-            {
-              // type: 'time',
-              display: false,
-              ticks: {
+          responsive: true,
+          maintainAspectRatio: false,
+          legend: {
+            display: false,
+          },
+          scales: {
+            xAxes: [
+              {
+                // type: 'time',
                 display: false,
+                ticks: {
+                  display: false,
+                },
+                gridLines: { display: false, drawBorder: false },
               },
-              gridLines: { display: false, drawBorder: false },
-            },
-          ],
-          yAxes: [
-            {
-              ticks: {
-                display: false,
-                min: min - max * 0.01,
-                max: max + max * 0.01,
+            ],
+            yAxes: [
+              {
+                ticks: {
+                  display: false,
+                  min: min - max * 0.01,
+                  max: max + max * 0.01,
+                },
+                gridLines: { display: false, drawBorder: false },
               },
-              gridLines: { display: false, drawBorder: false },
-            },
-          ],
-        },
-        /*tooltips: {
+            ],
+          },
+          /*tooltips: {
           enabled: true,
           mode: 'nearest',
           intersect: false,
         },*/
-        layout: {
-          padding: {
-            left: 0,
-            right: 0,
-            top: 7,
-            bottom: 0,
+          layout: {
+            padding: {
+              left: 0,
+              right: 0,
+              top: 7,
+              bottom: 0,
+            },
           },
         },
-      },
-    })
+      })
+    )
     // ref.current.style.height = '100px'
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chartData, chartDurationSeconds, chartFromTs])
 
   return (


### PR DESCRIPTION
## Jira ticket
https://ideamarketio.atlassian.net/browse/IDEAMARKET-144

## Summary

- The issue was that multiple charts were being connected to one single ref. By destroying the chart inside useEffect, we make sure that there is only one single chart at a time