### PR TITLE
feat: lodash treeshaking import

### DIFF
--- a/src/components/listing-page/ListingStats.tsx
+++ b/src/components/listing-page/ListingStats.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import array from 'lodash/array'
 import {
   ListingOverview,
   TimeXFloatYChartInLine,
@@ -21,6 +20,7 @@ import {
   WEEK_SECONDS,
   YEAR_SECONDS,
 } from 'utils'
+import { array } from 'utils/lodash'
 import ChartDurationEntry from './ChartDurationEntry'
 
 export default function ListingStats({ isLoading, market, token }) {

--- a/src/components/tokens/OverviewTokenTable.tsx
+++ b/src/components/tokens/OverviewTokenTable.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from 'react'
 import { useInfiniteQuery, useQuery } from 'react-query'
-import { flatten } from 'lodash'
 
 import { WEEK_SECONDS } from 'utils'
 import {
@@ -21,6 +20,7 @@ import TokenRow from './OverviewTokenRow'
 import TokenRowSkeleton from './OverviewTokenRowSkeleton'
 import { OverviewColumns } from './table/OverviewColumns'
 import { MainFilters } from './utils/OverviewUtils'
+import { flatten } from 'utils/lodash'
 
 type Props = {
   selectedMarkets: Set<string>

--- a/src/components/trade/ApproveButton.tsx
+++ b/src/components/trade/ApproveButton.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
 import classNames from 'classnames'
 import BN from 'bn.js'
-import _ from 'lodash'
 
 import { useTokenAllowance, approveToken } from '../../actions'
 import { TransactionManager, web3UintMax } from '../../utils'
 import Tooltip from 'components/tooltip/Tooltip'
+import { cloneDeep } from 'utils/lodash'
 
 export default function ApproveButton({
   tokenAddress,
@@ -59,7 +59,7 @@ export default function ApproveButton({
       return
     }
 
-    const allowances = _.cloneDeep(hasAllowanceFor)
+    const allowances = cloneDeep(hasAllowanceFor)
     if (!allowances[tokenAddress]) {
       allowances[tokenAddress] = {}
     }

--- a/src/store/markets/index.ts
+++ b/src/store/markets/index.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import create from 'zustand'
 
 import TwitterMarketSpecifics from './twitter'
@@ -6,6 +5,7 @@ import SubstackMarketSpecifics from './substack'
 import ShowtimeMarketSpecifics from './showtime'
 import TwitchMarketSpecifics from './twitch'
 import { queryMarkets } from 'store/ideaMarketsStore'
+import { find } from 'utils/lodash'
 
 export type IMarketSpecifics = {
   // Market
@@ -52,13 +52,13 @@ export function getMarketSpecifics() {
 export function getMarketSpecificsByMarketName(
   marketName: string
 ): IMarketSpecifics {
-  return _.find(specifics, (s) => s.getMarketName() === marketName)
+  return find(specifics, (s) => s.getMarketName() === marketName)
 }
 
 export function getMarketSpecificsByMarketNameInURLRepresentation(
   marketNameInURLRepresentation: string
 ): IMarketSpecifics {
-  return _.find(
+  return find(
     specifics,
     (s) => s.getMarketNameURLRepresentation() === marketNameInURLRepresentation
   )

--- a/src/utils/lodash.ts
+++ b/src/utils/lodash.ts
@@ -1,0 +1,6 @@
+import flatten from 'lodash/flatten'
+import array from 'lodash/array'
+import cloneDeep from 'lodash/cloneDeep'
+import find from 'lodash/find'
+
+export { flatten, array, cloneDeep, find }


### PR DESCRIPTION
## Jira ticket
https://ideamarketio.atlassian.net/browse/IDEAMARKET-150

## Summary
The issue here is the big bundle size of the lodash package. In order to solve it, I've decided to change the way we import lodash functions. 

from `import { filter} from 'lodash'` to `import filter from 'lodash'/filter` and all the util functions are reexported from lodash.ts file

Which should only import needed function, instead of loading the full library. Lodash functions are somethings quite useful, so we can still use lodash functions if needed.

explained here: https://www.azavea.com/blog/2019/03/07/lessons-on-tree-shaking-lodash/

Another solution would be to use for example [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash), which will automatically change the import for us
