### PR TITLE
Eth address

### DIFF
--- a/src/components/account/AccountInnerForm.tsx
+++ b/src/components/account/AccountInnerForm.tsx
@@ -7,6 +7,7 @@ import { signOut } from 'next-auth/client'
 import { accountTabs } from './constants'
 import { AccountContext } from 'pages/account'
 import ProfileWallet from './ProfileWallet'
+import copy from 'copy-to-clipboard'
 
 const AccountInnerForm = () => {
   const { getValues, isUpdateLoading, cardTab } = useContext(AccountContext)
@@ -45,26 +46,34 @@ const AccountInnerForm = () => {
 
           <div className="p-3 border-b border-gray-100 dark:border-gray-400">
             <div className="text-xs text-blue-400">USERNAME</div>
-            <div className="text-3xl font-semibold break-all">
-              {username ?? ''}
-            </div>
+            <div className="text-3xl font-semibold">{username ?? ''}</div>
           </div>
           {displayEmail && (
             <div className="p-3 border-b border-gray-100 dark:border-gray-400">
               <div className="text-xs text-blue-400">EMAIL ADDRESS</div>
-              <div break-all>{email}</div>
+              <div>{email}</div>
             </div>
           )}
           {displayEthAddresses && (
             <div className="p-3 border-b border-gray-100 dark:border-gray-400">
               <div className="text-xs text-blue-400">ETH ADDRESS</div>
-              <div break-all>{ethAddresses || ''}</div>
+              <div
+                onClick={() => copy(ethAddresses)}
+                className="cursor-pointer"
+              >
+                {ethAddresses
+                  ? ethAddresses?.substr(
+                      0,
+                      ethAddresses?.length > 16 ? 16 : ethAddresses?.length
+                    ) + (ethAddresses?.length > 16 ? '...' : '')
+                  : ''}
+              </div>
             </div>
           )}
           {displayBio && (
             <div>
               <div className="p-3 text-xs text-blue-400">BIO</div>
-              <div className="leading-5 break-all">{bio || ''}</div>
+              <div className="leading-5">{bio || ''}</div>
             </div>
           )}
 

--- a/src/components/account/SettingsTab.tsx
+++ b/src/components/account/SettingsTab.tsx
@@ -21,7 +21,7 @@ const SettingsTab = () => {
 
               <input
                 type="text"
-                className="block w-full h-8 break-all border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
+                className="block w-full h-8 border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
                 {...register('username')}
                 onChange={(e) => {
                   if (!username) {
@@ -35,7 +35,7 @@ const SettingsTab = () => {
               <span>Email Address</span>
               <input
                 type="email"
-                className="block w-full h-8 break-all border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
+                className="block w-full h-8 border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
                 placeholder="you@example.com"
                 {...register('email')}
                 disabled
@@ -46,7 +46,7 @@ const SettingsTab = () => {
               <span>Eth address</span>
               <input
                 type="text"
-                className="block w-full h-8 break-all border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
+                className="block w-full h-8 border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
                 {...register('ethAddresses')}
                 disabled={isUpdateLoading}
               />
@@ -56,7 +56,7 @@ const SettingsTab = () => {
               <span>Redirection url</span>
               <input
                 type="text"
-                className="block w-full h-8 break-all border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
+                className="block w-full h-8 border-gray-300 rounded-md shadow-sm sm:w-64 sm:text-sm focus:outline-none dark:text-gray-300 dark:bg-gray-600 dark:placeholder-gray-200 dark:border-gray-500 focus:ring-brand-blue focus:border-brand-blue"
                 {...register('redirectionUrl')}
                 disabled={isUpdateLoading}
               />
@@ -68,7 +68,7 @@ const SettingsTab = () => {
                 placeholder="Bio"
                 {...register('bio')}
                 disabled={isUpdateLoading}
-                className="w-full break-all border-gray-300 rounded-md sm:w-64 dark:border-gray-500 dark:bg-gray-600"
+                className="w-full border-gray-300 rounded-md sm:w-64 dark:border-gray-500 dark:bg-gray-600"
               />
             </div>
 


### PR DESCRIPTION
## Summary

- Got rid of `break-all` attribute because it wasn't doing anything. Got rid of CSS `break-all` because design didn't use that
- Made the ETH address copyable. Later on we can probably make it more obvious that you can copy these using an icon or something 
- Made it so only 16 characters of the ETH address can be displayed at most