### PR TITLE
Account design

### DIFF
--- a/src/components/account/AccountInnerForm.tsx
+++ b/src/components/account/AccountInnerForm.tsx
@@ -7,9 +7,9 @@ import { accountTabs } from './constants'
 import { AccountContext } from 'pages/account'
 import ProfileWallet from './ProfileWallet'
 import copy from 'copy-to-clipboard'
-import { PlusCircleIcon, MinusCircleIcon } from '@heroicons/react/outline'
+import { MinusCircleIcon } from '@heroicons/react/outline'
 import ModalService from 'components/modals/ModalService'
-import AddWalletModal from './AddWalletModal'
+import VerifyWalletModal from './VerifyWalletModal'
 import { BadgeCheckIcon } from '@heroicons/react/solid'
 import { SignedAddress } from 'types/customTypes'
 
@@ -68,16 +68,10 @@ const AccountInnerForm = ({
             <div className="p-3 border-b border-gray-100 dark:border-gray-400">
               <div className="flex justify-center items-center">
                 <div className="text-xs text-blue-400 mr-2">ETH ADDRESS</div>
-                <PlusCircleIcon
-                  onClick={() =>
-                    ModalService.open(AddWalletModal, { submitWallet })
-                  }
-                  className="w-5 h-5 cursor-pointer"
-                />
               </div>
               <div className="cursor-pointer">
                 {ethAddresses?.map((ethAddress, index) => (
-                  <div className="flex items-center">
+                  <div className="flex items-center" key={index}>
                     {ethAddress.verified ? (
                       <BadgeCheckIcon className="w-5 h-5 flex-shrink-0" />
                     ) : (
@@ -112,12 +106,23 @@ const AccountInnerForm = ({
           )}
 
           {cardTab === accountTabs.SETTINGS && (
-            <button
-              className="py-2 m-3 text-white rounded-lg bg-brand-blue hover:bg-blue-800"
-              type="submit"
-            >
-              {isUpdateLoading ? <p>Saving...</p> : <p> Save Profile</p>}
-            </button>
+            <>
+              <button
+                onClick={() =>
+                  ModalService.open(VerifyWalletModal, { submitWallet })
+                }
+                className="py-2 m-3 text-white rounded-lg bg-brand-blue hover:bg-blue-800"
+                type="button"
+              >
+                <p>Verify Wallet</p>
+              </button>
+              <button
+                className="py-2 m-3 text-white rounded-lg bg-brand-blue hover:bg-blue-800"
+                type="submit"
+              >
+                {isUpdateLoading ? <p>Saving...</p> : <p> Save Profile</p>}
+              </button>
+            </>
           )}
         </div>
         {cardTab === accountTabs.SETTINGS && <SettingsTab />}

--- a/src/components/account/VerifyWalletModal.tsx
+++ b/src/components/account/VerifyWalletModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import classNames from 'classnames'
-import { Modal, CircleSpinner } from '../'
+import { Modal, CircleSpinner } from '..'
 import ModalService from '../modals/ModalService'
 import WalletModal from '../wallet/WalletModal'
 import { useWeb3React } from '@web3-react/core'
@@ -19,7 +19,7 @@ type Props = {
   submitWallet: (signedAddress: SignedAddress) => void
 }
 
-export default function AddWalletModal({ close, submitWallet }: Props) {
+export default function VerifyWalletModal({ close, submitWallet }: Props) {
   const { library, account } = useWeb3React()
 
   const [verificationState, setVerificationState] = useState(
@@ -94,19 +94,16 @@ export default function AddWalletModal({ close, submitWallet }: Props) {
       <div className="md:min-w-150 md:max-w-150">
         <div className="p-4 bg-top-mobile ">
           <p className="text-2xl text-center text-gray-300 md:text-3xl font-gilroy-bold">
-            Add Wallet
+            Verify Wallet
           </p>
         </div>
         <div className="p-5 text-brand-gray-2 dark:text-gray-300">
           {verificationState === STATE.OWNER_ADDRESS && (
             <>
-              <p className="text-sm text-center">
-                In order to add the connected address, you need to verify
-                ownership.
+              <p className="text-sm text-center mb-5">
+                In order to display connected address publicly, you need to
+                verify ownership.
               </p>
-              <div className="my-5 p-5 border border-brand-gray-2 bg-gray-200 rounded text-black text-center">
-                Ideamarket - Prove Ownership: {uuid}
-              </div>
               <div className="flex flex-col items-center justify-center mt-1 md:flex-row md:mx-2">
                 <button
                   className="mt-2 md:mt-0 md:ml-2.5 w-32 h-10 text-sm text-brand-blue bg-white border border-brand-blue rounded-lg hover:bg-brand-blue hover:text-white"

--- a/src/components/account/VisibilityOptions.tsx
+++ b/src/components/account/VisibilityOptions.tsx
@@ -26,7 +26,7 @@ const VisibilityOptions = () => {
           />
         </div>
         <div className="flex items-center justify-between">
-          <span> Eth Addresses</span>
+          <span> ETH Addresses</span>
           <input
             className="rounded-lg cursor-pointer"
             type="checkbox"

--- a/src/components/wallet/WalletInterface.tsx
+++ b/src/components/wallet/WalletInterface.tsx
@@ -20,6 +20,7 @@ import {
   connectorsById,
   ConnectorIds,
 } from 'wallets/connectors/index'
+import { useCustomSession } from 'utils/useCustomSession'
 
 export default function WalletInterface({
   onWalletConnected,
@@ -33,12 +34,14 @@ export default function WalletInterface({
   const { active, account, library, connector, activate, deactivate } =
     useWeb3React()
 
+  const { session, loading, refetchSession } = useCustomSession()
+
   // handle logic to recognize the connector currently being activated
   const [activatingConnector, setActivatingConnector] = useState<any>()
 
   useEffect(() => {
     const setWeb3WithWait = async () => {
-      await setWeb3(library, connectingWallet)
+      await setWeb3(library, connectingWallet, session, refetchSession)
 
       if (onWalletConnectedCallback) {
         onWalletConnectedCallback()
@@ -70,7 +73,7 @@ export default function WalletInterface({
       setActivatingConnector(undefined)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activatingConnector, connector])
+  }, [activatingConnector, connector, loading])
 
   async function onWalletClicked(wallet) {
     setConnectingWallet(wallet)

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -5,6 +5,7 @@ import { initContractsFromWeb3, clearContracts } from './contractStore'
 
 import ENS, { getEnsAddress } from '@ensdomains/ensjs'
 import { NETWORK } from 'store/networks'
+import { checkForNewAddresses } from 'lib/utils/address'
 
 type State = {
   web3: Web3
@@ -30,10 +31,10 @@ async function handleWeb3Change() {
     web3.currentProvider.off('accountsChanged', handleWeb3Change)
   }
 
-  await setWeb3(web3, localStorage.getItem('WALLET_TYPE'))
+  await setWeb3(web3, localStorage.getItem('WALLET_TYPE'), null, () => null)
 }
 
-export async function setWeb3(web3, wallet) {
+export async function setWeb3(web3, wallet, session, refetchSession) {
   const address = (await web3.eth.getAccounts())[0]
   web3.eth.defaultAccount = address
 
@@ -56,6 +57,8 @@ export async function setWeb3(web3, wallet) {
     chainID: chainID,
     ens,
   })
+
+  checkForNewAddresses(address, session, refetchSession)
 
   if (wallet) {
     localStorage.setItem('WALLET_TYPE', wallet.toString())

--- a/src/wallets/hooks.ts
+++ b/src/wallets/hooks.ts
@@ -3,9 +3,11 @@ import { useWeb3React } from '@web3-react/core'
 import { setWeb3 } from 'store/walletStore'
 
 import { injected, connectorsById } from './connectors/index'
+import { useCustomSession } from 'utils/useCustomSession'
 
 export function useEagerConnect() {
   const { activate, active, library } = useWeb3React()
+  const { session, loading, refetchSession } = useCustomSession()
 
   const [tried, setTried] = useState(false)
 
@@ -41,11 +43,11 @@ export function useEagerConnect() {
 
   // if the connection worked, wait until we get confirmation of that to flip the flag
   useEffect(() => {
-    if (!tried && active) {
-      setWeb3(library, undefined)
+    if (!tried && !loading && active) {
+      setWeb3(library, undefined, session, refetchSession)
       setTried(true)
     }
-  }, [tried, active, library])
+  }, [tried, active, library, session, refetchSession, loading])
 
   return tried
 }


### PR DESCRIPTION
## Jira ticket
https://ideamarketio.atlassian.net/browse/IDEAMARKET-180

## Summary
- When a wallet connects and user is signed in, link connected wallet to that profile. If they're already connected to a wallet and sign in, also link wallet to that profile
- Changed verify process design a bit. There will be more design changes to come

## Notes
- One edge case is whenever a user switches wallets inside of MetaMask (or other provider), our app cannot detect that, so address will not be linked immediately. One potential fix for this would be to store the user session globally using zustand instead of the hook we are currently using. Not totally confident that would work though.