### PR TITLE
fix: breaking staking page issue when wallet is not connected

### DIFF
--- a/src/actions/useClaimable.ts
+++ b/src/actions/useClaimable.ts
@@ -34,7 +34,10 @@ const useClaimable = (
 
   useEffect(() => {
     const run = async () => {
-      if (!isAddressInMerkleRoot(address, airdropType)) {
+      if (
+        !isAddressInMerkleRoot(address, airdropType) ||
+        !merkleDistributorContract
+      ) {
         setBalance(0)
         return
       }

--- a/src/actions/useClaimableRewardsIMO.ts
+++ b/src/actions/useClaimableRewardsIMO.ts
@@ -17,6 +17,10 @@ export default function useClaimableRewardsIMO(
     let isCancelled = false
     const getBalance = async () => {
       return new Promise<BN>((resolve) => {
+        if (!sushiStaking) {
+          resolve(new BN('0'))
+          return
+        }
         sushiStaking.methods
           .pendingIMO(0, user)
           .call()

--- a/src/actions/useLPStakedBalance.ts
+++ b/src/actions/useLPStakedBalance.ts
@@ -17,6 +17,10 @@ export default function useLPStakedBalance(
     let isCancelled = false
     const getBalance = async () => {
       return new Promise<BN>((resolve) => {
+        if (!sushiStaking) {
+          resolve(new BN('0'))
+          return
+        }
         sushiStaking.methods
           .userInfo(0, user)
           .call()


### PR DESCRIPTION
Staking page used to be broken when the wallet is not connected because contract methods can not be called.

Fixed this by checking if contract is `undefined` or not at first before the actual calling of contract methods.